### PR TITLE
fix unique messageId in the SenderAdapter

### DIFF
--- a/contracts/adapters/base/BaseSenderAdapter.sol
+++ b/contracts/adapters/base/BaseSenderAdapter.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.17;
+
+abstract contract BaseSenderAdapter {
+    uint256 public nonce;
+
+    /**
+     * @notice Get new message Id and increment nonce
+     * @param _toChainId is the destination chainId.
+     * @param _to is the contract address on the destination chain.
+     * @param _data is the data to be sent to _to by low-level call(eg. address(_to).call(_data)).
+     */
+
+    function _getNewMessageId(
+        uint256 _toChainId,
+        address _to,
+        bytes memory _data
+    ) internal returns (bytes32 messageId) {
+        bytes32 messageId = keccak256(abi.encodePacked(getChainId(), _toChainId, nonce, address(this), _to, _data));
+        nonce++;
+    }
+
+    /// @dev Get current chain id
+    function getChainId() public view virtual returns (uint256 cid) {
+        assembly {
+            cid := chainid()
+        }
+    }
+}

--- a/contracts/adapters/base/BaseSenderAdapter.sol
+++ b/contracts/adapters/base/BaseSenderAdapter.sol
@@ -9,15 +9,13 @@ abstract contract BaseSenderAdapter {
      * @notice Get new message Id and increment nonce
      * @param _toChainId is the destination chainId.
      * @param _to is the contract address on the destination chain.
-     * @param _data is the data to be sent to _to by low-level call(eg. address(_to).call(_data)).
      */
 
     function _getNewMessageId(
         uint256 _toChainId,
-        address _to,
-        bytes memory _data
+        address _to
     ) internal returns (bytes32 messageId) {
-        bytes32 messageId = keccak256(abi.encodePacked(getChainId(), _toChainId, nonce, address(this), _to, _data));
+        bytes32 messageId = keccak256(abi.encodePacked(getChainId(), _toChainId, nonce, address(this), _to));
         nonce++;
     }
 

--- a/contracts/adapters/debridge/DeBridgeSenderAdapter.sol
+++ b/contracts/adapters/debridge/DeBridgeSenderAdapter.sol
@@ -2,17 +2,17 @@
 
 pragma solidity 0.8.17;
 
-import "../../interfaces/IBridgeSenderAdapter.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
+import "../base/BaseSenderAdapter.sol";
+import "../../interfaces/IBridgeSenderAdapter.sol";
 import "./interfaces/IDeBridgeGate.sol";
 import "./interfaces/IDeBridgeReceiverAdapter.sol";
 
-contract DeBridgeSenderAdapter is IBridgeSenderAdapter, Ownable {
+contract DeBridgeSenderAdapter is IBridgeSenderAdapter, Ownable, BaseSenderAdapter {
     /* ========== STATE VARIABLES ========== */
 
     string public constant name = "deBridge";
     IDeBridgeGate public immutable deBridgeGate;
-    uint32 public nonce;
 
     // dstChainId => receiverAdapter address
     mapping(uint256 => address) public receiverAdapters;
@@ -29,11 +29,7 @@ contract DeBridgeSenderAdapter is IBridgeSenderAdapter, Ownable {
 
     /* ========== PUBLIC METHODS ========== */
 
-    function getMessageFee(
-        uint256,
-        address,
-        bytes calldata
-    ) external view returns (uint256) {
+    function getMessageFee(uint256, address, bytes calldata) external view returns (uint256) {
         return deBridgeGate.globalFixedNativeFee();
     }
 
@@ -44,7 +40,7 @@ contract DeBridgeSenderAdapter is IBridgeSenderAdapter, Ownable {
     ) external payable override returns (bytes32) {
         require(receiverAdapters[_toChainId] != address(0), "no receiver adapter");
         address receiver = receiverAdapters[_toChainId];
-        bytes32 msgId = bytes32(uint256(nonce));
+        bytes32 msgId = _getNewMessageId(_toChainId, _to, _data);
         bytes memory executeMethodData = abi.encodeWithSelector(
             IDeBridgeReceiverAdapter.executeMessage.selector,
             msg.sender,
@@ -60,17 +56,16 @@ contract DeBridgeSenderAdapter is IBridgeSenderAdapter, Ownable {
         );
 
         emit MessageDispatched(msgId, msg.sender, _toChainId, _to, _data);
-        nonce++;
+
         return msgId;
     }
 
     /* ========== ADMIN METHODS ========== */
 
-    function updateReceiverAdapter(uint256[] calldata _dstChainIds, address[] calldata _receiverAdapters)
-        external
-        override
-        onlyOwner
-    {
+    function updateReceiverAdapter(
+        uint256[] calldata _dstChainIds,
+        address[] calldata _receiverAdapters
+    ) external override onlyOwner {
         require(_dstChainIds.length == _receiverAdapters.length, "mismatch length");
         for (uint256 i = 0; i < _dstChainIds.length; i++) {
             receiverAdapters[_dstChainIds[i]] = _receiverAdapters[i];

--- a/contracts/adapters/debridge/DeBridgeSenderAdapter.sol
+++ b/contracts/adapters/debridge/DeBridgeSenderAdapter.sol
@@ -40,7 +40,7 @@ contract DeBridgeSenderAdapter is IBridgeSenderAdapter, Ownable, BaseSenderAdapt
     ) external payable override returns (bytes32) {
         require(receiverAdapters[_toChainId] != address(0), "no receiver adapter");
         address receiver = receiverAdapters[_toChainId];
-        bytes32 msgId = _getNewMessageId(_toChainId, _to, _data);
+        bytes32 msgId = _getNewMessageId(_toChainId, _to);
         bytes memory executeMethodData = abi.encodeWithSelector(
             IDeBridgeReceiverAdapter.executeMessage.selector,
             msg.sender,


### PR DESCRIPTION
- Added BaseSenderAdapter that encapsulates the calculation of message Id logic
- MessageId is calculated as the hash from all message's args and contract nonce.
- Added inheritance to DeBridgeSenderAdapter from BaseSenderAdapter

If PR will be approved we need to patch other sender adapters too