### PR TITLE
add Telepathy protocol

### DIFF
--- a/contracts/adapters/Telepathy/TelepathyReceiverAdapter.sol
+++ b/contracts/adapters/Telepathy/TelepathyReceiverAdapter.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity 0.8.17;
+
+import {ITelepathyHandler} from "./interfaces/ITelepathy.sol";
+import {IBridgeReceiverAdapter} from "../../interfaces/IBridgeReceiverAdapter.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+contract TelepathyReceiverAdapter is IBridgeReceiverAdapter, ITelepathyHandler, Ownable {
+    /* ========== EVENTS ========== */
+
+    event SenderAdapterUpdated(uint256 srcChainId, address senderAdapter);
+
+    /* ========== ERRORS ========== */
+
+    error NotFromTelepathyRouter(address sender);
+    error InvalidSenderAdapter(address senderAdapter);
+    error MismatchAdapterArrLength(uint256 chainIdsLength, uint256 adaptersLength);
+
+    /* ========== STATE VARIABLES ========== */
+
+    address public immutable telepathyRouter;
+
+    /// @dev srcChainId => senderAdapter
+    mapping(uint256 => address) public senderAdapters;
+    /// @dev msgId => isExecuted
+    mapping(bytes32 => bool) public executedMessages;
+
+    /* ========== CONSTRUCTOR  ========== */
+
+    constructor(address _telepathyRouter) {
+        telepathyRouter = _telepathyRouter;
+    }
+
+    /* ========== EXTERNAL METHODS ========== */
+    
+    /// @dev The checks for MessageIdAlreadyExecuted
+    function handleTelepathy(uint32 _srcChainId, address _srcAddress, bytes memory _message) external returns (bytes4) {
+        // Validation
+        if (msg.sender != telepathyRouter) {
+            revert NotFromTelepathyRouter(msg.sender);
+        }
+        (bytes32 msgId, address multiMessageSender, address multiMessageReceiver, bytes memory data) =
+            abi.decode(_message, (bytes32, address, address, bytes));
+        if (_srcAddress != senderAdapters[uint256(_srcChainId)]) {
+            revert InvalidSenderAdapter(_srcAddress);
+        }
+        if (executedMessages[msgId]) {
+            revert MessageIdAlreadyExecuted(msgId);
+        }
+        executedMessages[msgId] = true;
+
+        // Pass message on to the MultiMessageReceiver
+        (bool success, bytes memory lowLevelData) =
+            multiMessageReceiver.call(abi.encodePacked(data, msgId, uint256(_srcChainId), multiMessageSender));
+        if (!success) {
+            revert MessageFailure(msgId, lowLevelData);
+        }
+
+        emit MessageIdExecuted(uint256(_srcChainId), msgId);
+        return ITelepathyHandler.handleTelepathy.selector;
+    }
+
+    /* ========== ADMIN METHODS ========== */
+
+    function updateSenderAdapter(uint256[] calldata _srcChainIds, address[] calldata _senderAdapters)
+        external
+        override
+        onlyOwner
+    {
+        if (_srcChainIds.length != _senderAdapters.length) {
+            revert MismatchAdapterArrLength(_srcChainIds.length, _senderAdapters.length);
+        }
+        for (uint256 i; i < _srcChainIds.length; ++i) {
+            senderAdapters[_srcChainIds[i]] = _senderAdapters[i];
+            emit SenderAdapterUpdated(_srcChainIds[i], _senderAdapters[i]);
+        }
+    }
+}

--- a/contracts/adapters/Telepathy/TelepathySenderAdapter.sol
+++ b/contracts/adapters/Telepathy/TelepathySenderAdapter.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity 0.8.17;
+
+import {ITelepathyRouter} from "./interfaces/ITelepathy.sol";
+import {IBridgeSenderAdapter} from "../../interfaces/IBridgeSenderAdapter.sol";
+import {BaseSenderAdapter} from "../base/BaseSenderAdapter.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+contract TelepathySenderAdapter is IBridgeSenderAdapter, BaseSenderAdapter, Ownable {
+    /* ========== EVENTS ========== */
+
+    event ReceiverAdapterUpdated(uint256 dstChainId, address receiverAdapter);
+
+    /* ========== ERRORS ========== */
+
+    error MismatchAdapterArrLength(uint256 chainIdsLength, uint256 adaptersLength);
+
+    /* ========== STATE VARIABLES ========== */
+
+    string public constant name = "telepathy";
+    address public immutable telepathyRouter;
+
+    /// @dev dstChainId => receiverAdapter
+    mapping(uint256 => address) public receiverAdapters;
+
+    /* ========== CONSTRUCTOR  ========== */
+
+    constructor(address _telepathyRouter) {
+        telepathyRouter = _telepathyRouter;
+    }
+
+    /* ========== EXTERNAL METHODS ========== */
+
+    /// @dev Telepathy does not have a fee and will subsidize the cost of execution for these messages.
+    function getMessageFee(uint256, address, bytes calldata) external pure returns (uint256) {
+        return 0;
+    }
+
+    /// @notice Send a message message to the Telepathy Router.
+    function dispatchMessage(uint256 _toChainId, address _to, bytes calldata _data)
+        external
+        payable
+        override
+        returns (bytes32)
+    {
+        bytes32 msgId = _getNewMessageId(_toChainId, _to);
+        bytes memory message = abi.encodePacked(msgId, msg.sender, _to, _data);
+
+        ITelepathyRouter(telepathyRouter).send(uint32(_toChainId), receiverAdapters[_toChainId], message);
+        emit MessageDispatched(msgId, msg.sender, _toChainId, _to, _data);
+
+        return msgId;
+    }
+
+    /* ========== ADMIN METHODS ========== */
+
+    function updateReceiverAdapter(uint256[] calldata _dstChainIds, address[] calldata _receiverAdapters)
+        external
+        override
+        onlyOwner
+    {
+        if (_dstChainIds.length != _receiverAdapters.length) {
+            revert MismatchAdapterArrLength(_dstChainIds.length, _receiverAdapters.length);
+        }
+        for (uint256 i; i < _dstChainIds.length; ++i) {
+            receiverAdapters[_dstChainIds[i]] = _receiverAdapters[i];
+            emit ReceiverAdapterUpdated(_dstChainIds[i], _receiverAdapters[i]);
+        }
+    }
+}

--- a/contracts/adapters/Telepathy/interfaces/ITelepathy.sol
+++ b/contracts/adapters/Telepathy/interfaces/ITelepathy.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+pragma solidity 0.8.17;
+
+interface ITelepathyRouter {
+    event SentMessage(uint64 indexed nonce, bytes32 indexed msgHash, bytes message);
+
+    function send(uint32 destinationChainId, bytes32 destinationAddress, bytes calldata data)
+        external
+        returns (bytes32);
+
+    function send(uint32 destinationChainId, address destinationAddress, bytes calldata data)
+        external
+        returns (bytes32);
+
+    function sendViaStorage(uint32 destinationChainId, bytes32 destinationAddress, bytes calldata data)
+        external
+        returns (bytes32);
+
+    function sendViaStorage(uint32 destinationChainId, address destinationAddress, bytes calldata data)
+        external
+        returns (bytes32);
+}
+
+interface ITelepathyReceiver {
+    event ExecutedMessage(
+        uint32 indexed sourceChainId, uint64 indexed nonce, bytes32 indexed msgHash, bytes message, bool status
+    );
+
+    function executeMessage(
+        uint64 slot,
+        bytes calldata message,
+        bytes[] calldata accountProof,
+        bytes[] calldata storageProof
+    ) external;
+
+    function executeMessageFromLog(
+        bytes calldata srcSlotTxSlotPack,
+        bytes calldata messageBytes,
+        bytes32[] calldata receiptsRootProof,
+        bytes32 receiptsRoot,
+        bytes[] calldata receiptProof, // receipt proof against receipt root
+        bytes memory txIndexRLPEncoded,
+        uint256 logIndex
+    ) external;
+}
+
+interface ITelepathyHandler {
+    function handleTelepathy(uint32 _sourceChainId, address _sourceAddress, bytes memory _data)
+        external
+        returns (bytes4);
+}


### PR DESCRIPTION
This PR enables the [Telepathy Protocol](https://www.telepathy.xyz/) to work with the [Multi-Message Aggregation (MMA)](https://github.com/MultiMessageAggregation/multibridge) project. This is made possible with the new [TelepathySenderAdapter](https://github.com/mattstam/multibridge/blob/4349836ff3e64c630dd1ee529bfeb16762bfcbca/contracts/adapters/Telepathy/TelepathySenderAdapter.sol#L10) and [TelepathyReceiverAdapter](https://github.com/mattstam/multibridge/blob/706dcfb61fff045a59961d1851f77d4417753bd6/contracts/adapters/Telepathy/TelepathyReceiverAdapter.sol#L9). 

For more information on Telepathy, please see the [docs](https://docs.telepathy.xyz/)!