### PR TITLE
Improve CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,4 +85,5 @@ jobs:
           fail-on: high
           ignore-compile: true
           solc-version: 0.8.19
+          slither-args: --checklist --markdown-root ${{ github.server_url }}/${{ github.repository }}/blob/${{ github.sha }}/
           slither-config: "slither.config.json"

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,19 +3,17 @@ src = "src"
 out = "out"
 libs = ["lib"]
 solc = "0.8.19"
-
-optimizer = true
+optimizer = false
 runs = 100
-viaIR = true
+viaIR = false
 
-[profile.local]
+[profile.prod]
 src = "src"
 out = "out"
 libs = ["lib"]
 solc = "0.8.19"
-
-optimizer = false
+optimizer = true
 runs = 100
-viaIR = false
+viaIR = true
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config


### PR DESCRIPTION
This PR turns off the compiler optimizer by default and improves the Slither analysis output on the CI environment.