### PR TITLE
Add missing validations

### DIFF
--- a/src/MultiMessageSender.sol
+++ b/src/MultiMessageSender.sol
@@ -224,6 +224,10 @@ contract MultiMessageSender {
             revert Error.ZERO_CHAIN_ID();
         }
 
+        if (_dstChainId == block.chainid) {
+            revert Error.INVALID_DST_CHAIN();
+        }
+
         if (_target == address(0)) {
             revert Error.INVALID_TARGET();
         }

--- a/src/adapters/axelar/AxelarReceiverAdapter.sol
+++ b/src/adapters/axelar/AxelarReceiverAdapter.sol
@@ -80,14 +80,14 @@ contract AxelarReceiverAdapter is IAxelarExecutable, IMessageReceiverAdapter {
             revert Error.INVALID_SENDER_CHAIN_ID();
         }
 
-        /// @dev step-2: validate the contract call
-        if (!gateway.validateContractCall(commandId, sourceChain, sourceAddress, keccak256(payload))) {
-            revert Error.NOT_APPROVED_BY_GATEWAY();
-        }
-
-        /// @dev step-3: validate the source address
+        /// @dev step-2: validate the source address
         if (sourceAddress.toAddress() != senderAdapter) {
             revert Error.INVALID_SENDER_ADAPTER();
+        }
+
+        /// @dev step-3: validate the contract call
+        if (!gateway.validateContractCall(commandId, sourceChain, sourceAddress, keccak256(payload))) {
+            revert Error.NOT_APPROVED_BY_GATEWAY();
         }
 
         /// decode the cross-chain payload

--- a/src/adapters/wormhole/WormholeReceiverAdapter.sol
+++ b/src/adapters/wormhole/WormholeReceiverAdapter.sol
@@ -57,6 +57,9 @@ contract WormholeReceiverAdapter is IMessageReceiverAdapter, IWormholeReceiver {
     /// @param _gac is global access controller.
     /// note: https://docs.wormhole.com/wormhole/quick-start/cross-chain-dev/automatic-relayer
     constructor(address _relayer, address _gac) {
+        if (_relayer == address(0) || _gac == address(0)) {
+            revert Error.ZERO_ADDRESS_INPUT();
+        }
         relayer = _relayer;
         gac = IGAC(_gac);
     }

--- a/src/adapters/wormhole/WormholeSenderAdapter.sol
+++ b/src/adapters/wormhole/WormholeSenderAdapter.sol
@@ -48,7 +48,7 @@ contract WormholeSenderAdapter is BaseSenderAdapter {
         uint16 wormChainId = chainIdMap[_toChainId];
 
         if (wormChainId == 0) {
-            revert Error.ZERO_CHAIN_ID();
+            revert Error.INVALID_DST_CHAIN();
         }
 
         msgId = _getNewMessageId(_toChainId, _to);

--- a/test/unit-tests/MultiMessageSender.t.sol
+++ b/test/unit-tests/MultiMessageSender.t.sol
@@ -181,6 +181,14 @@ contract MultiMessageSenderTest is Setup {
         sender.remoteCall(DST_CHAIN_ID, address(42), bytes("42"), 0, invalidExpMax, excludedAdapters);
     }
 
+    /// @dev dst chain cannot be the the sender chain
+    function test_remote_call_chain_id_is_sender_chain() public {
+        vm.startPrank(caller);
+
+        vm.expectRevert(Error.INVALID_DST_CHAIN.selector);
+        sender.remoteCall(block.chainid, address(42), bytes("42"), 0, EXPIRATION_CONSTANT);
+    }
+
     /// @dev cannot call with dst chain ID of 0
     function test_remote_call_zero_chain_id() public {
         vm.startPrank(caller);

--- a/test/unit-tests/adapters/wormhole/WormholeReceiverAdapter.t.sol
+++ b/test/unit-tests/adapters/wormhole/WormholeReceiverAdapter.t.sol
@@ -35,6 +35,18 @@ contract WormholeReceiverAdapterTest is Setup {
         assertEq(address(adapter.gac()), contractAddress[DST_CHAIN_ID]["GAC"]);
     }
 
+    /// @dev constructor cannot be called with zero address relayer
+    function test_constructor_zero_address_relayer() public {
+        vm.expectRevert(Error.ZERO_ADDRESS_INPUT.selector);
+        new WormholeReceiverAdapter(address(0), address(42));
+    }
+
+    /// @dev constructor cannot be called with zero address GAC
+    function test_constructor_zero_address_gac() public {
+        vm.expectRevert(Error.ZERO_ADDRESS_INPUT.selector);
+        new WormholeReceiverAdapter(address(42), address(0));
+    }
+
     /// @dev gets the name
     function test_name() public {
         assertEq(adapter.name(), "wormhole");

--- a/test/unit-tests/adapters/wormhole/WormholeSenderAdapter.t.sol
+++ b/test/unit-tests/adapters/wormhole/WormholeSenderAdapter.t.sol
@@ -67,7 +67,7 @@ contract WormholeSenderAdapterTest is Setup {
     }
 
     /// @dev cannot dispatch message to invalid dst chain
-    function test_dispatch_message_zero_chain_id() public {
+    function test_dispatch_message_unknown_chain_id() public {
         // clear chain ID map entry first
         vm.startPrank(owner);
         uint256[] memory origIds = new uint256[](1);
@@ -79,7 +79,7 @@ contract WormholeSenderAdapterTest is Setup {
         vm.startPrank(senderAddr);
         vm.deal(senderAddr, 1 ether);
 
-        vm.expectRevert(Error.ZERO_CHAIN_ID.selector);
+        vm.expectRevert(Error.INVALID_DST_CHAIN.selector);
         adapter.dispatchMessage{value: 1 ether}(DST_CHAIN_ID, address(42), bytes("42"));
     }
 


### PR DESCRIPTION
- Adds a zero address check to the Wormhole adapter constructor
- Ensures that the destination chain provided to the `MultiMessageSender` cannot be the be the source chain itself