### PR TITLE
Refactor message receiver interface

### DIFF
--- a/src/MultiMessageReceiver.sol
+++ b/src/MultiMessageReceiver.sol
@@ -102,12 +102,7 @@ contract MultiMessageReceiver is IMultiMessageReceiver, ExecutorAware, Initializ
 
     /// @notice receive messages from allowed bridge receiver adapters
     /// @param _message is the crosschain message sent by the mma sender
-    /// @param _bridgeName is the name of the bridge that relays the message
-    function receiveMessage(MessageLibrary.Message calldata _message, string memory _bridgeName)
-        external
-        override
-        onlyReceiverAdapter
-    {
+    function receiveMessage(MessageLibrary.Message calldata _message) external override onlyReceiverAdapter {
         if (_message.dstChainId != block.chainid) {
             revert Error.INVALID_DST_CHAIN();
         }
@@ -147,7 +142,8 @@ contract MultiMessageReceiver is IMultiMessageReceiver, ExecutorAware, Initializ
             );
         }
 
-        emit SingleBridgeMsgReceived(msgId, _bridgeName, _message.nonce, msg.sender);
+        string memory bridgeName = IMessageReceiverAdapter(msg.sender).name();
+        emit SingleBridgeMsgReceived(msgId, bridgeName, _message.nonce, msg.sender);
     }
 
     /// @notice Execute the message (invoke external call according to the message content) if the message

--- a/src/adapters/axelar/AxelarReceiverAdapter.sol
+++ b/src/adapters/axelar/AxelarReceiverAdapter.sol
@@ -19,7 +19,7 @@ import "./libraries/StringAddressConversion.sol";
 contract AxelarReceiverAdapter is IAxelarExecutable, IMessageReceiverAdapter {
     using StringAddressConversion for string;
 
-    string public constant name = "axelar";
+    string public constant name = "AXELAR";
     string public constant senderChain = "ethereum";
 
     IAxelarGateway public immutable gateway;
@@ -114,7 +114,7 @@ contract AxelarReceiverAdapter is IAxelarExecutable, IMessageReceiverAdapter {
 
         MessageLibrary.Message memory _data = abi.decode(decodedPayload.data, (MessageLibrary.Message));
 
-        try IMultiMessageReceiver(decodedPayload.finalDestination).receiveMessage(_data, name) {
+        try IMultiMessageReceiver(decodedPayload.finalDestination).receiveMessage(_data) {
             emit MessageIdExecuted(_data.srcChainId, msgId);
         } catch (bytes memory lowLevelData) {
             revert MessageFailure(msgId, lowLevelData);

--- a/src/adapters/wormhole/WormholeReceiverAdapter.sol
+++ b/src/adapters/wormhole/WormholeReceiverAdapter.sol
@@ -17,7 +17,7 @@ import "../../libraries/Message.sol";
 /// @dev allows wormhole relayers to write to receiver adapter which then forwards the message to
 /// the MMA receiver.
 contract WormholeReceiverAdapter is IMessageReceiverAdapter, IWormholeReceiver {
-    string public constant name = "wormhole";
+    string public constant name = "WORMHOLE";
     address public immutable relayer;
     IGAC public immutable gac;
     uint16 public immutable senderChain = uint16(2); // Wormhole chain ID for Ethereum
@@ -142,7 +142,7 @@ contract WormholeReceiverAdapter is IMessageReceiverAdapter, IWormholeReceiver {
 
         MessageLibrary.Message memory _data = abi.decode(decodedPayload.data, (MessageLibrary.Message));
 
-        try IMultiMessageReceiver(decodedPayload.finalDestination).receiveMessage(_data, name) {
+        try IMultiMessageReceiver(decodedPayload.finalDestination).receiveMessage(_data) {
             emit MessageIdExecuted(_data.srcChainId, msgId);
         } catch (bytes memory lowLevelData) {
             revert MessageFailure(msgId, lowLevelData);

--- a/src/interfaces/IMultiMessageReceiver.sol
+++ b/src/interfaces/IMultiMessageReceiver.sol
@@ -33,6 +33,5 @@ interface IMultiMessageReceiver {
 
     /// @notice Receive messages from allowed bridge receiver adapters.
     /// @dev Every receiver adapter should call this function with decoded MessageLibrary.Message
-    /// when receiver adapter receives a message produced by a corresponding sender adapter on the source chain.
-    function receiveMessage(MessageLibrary.Message calldata _message, string memory _bridgeName) external;
+    function receiveMessage(MessageLibrary.Message calldata _message) external;
 }

--- a/test/unit-tests/MultiMessageReceiver.t.sol
+++ b/test/unit-tests/MultiMessageReceiver.t.sol
@@ -168,7 +168,7 @@ contract MultiMessageReceiverTest is Setup {
         vm.expectEmit(true, true, true, true, address(receiver));
         emit SingleBridgeMsgReceived(msgId, "WORMHOLE", 42, wormholeAdapterAddr);
 
-        receiver.receiveMessage(message, "WORMHOLE");
+        receiver.receiveMessage(message);
 
         assertFalse(receiver.isExecuted(msgId));
 
@@ -200,10 +200,10 @@ contract MultiMessageReceiverTest is Setup {
         });
         bytes32 msgId = MessageLibrary.computeMsgId(message);
 
-        receiver.receiveMessage(message, "WORMHOLE");
+        receiver.receiveMessage(message);
 
         vm.startPrank(axelarAdapterAddr);
-        receiver.receiveMessage(message, "AXELAR");
+        receiver.receiveMessage(message);
 
         assertEq(receiver.msgDeliveryCount(msgId), 2);
     }
@@ -222,8 +222,7 @@ contract MultiMessageReceiverTest is Setup {
                 callData: bytes(""),
                 nativeValue: 0,
                 expiration: 0
-            }),
-            "WORMHOLE"
+            })
         );
     }
 
@@ -241,8 +240,7 @@ contract MultiMessageReceiverTest is Setup {
                 callData: bytes(""),
                 nativeValue: 0,
                 expiration: 0
-            }),
-            "WORMHOLE"
+            })
         );
     }
 
@@ -260,8 +258,7 @@ contract MultiMessageReceiverTest is Setup {
                 callData: bytes(""),
                 nativeValue: 0,
                 expiration: 0
-            }),
-            "WORMHOLE"
+            })
         );
     }
 
@@ -279,8 +276,7 @@ contract MultiMessageReceiverTest is Setup {
                 callData: bytes(""),
                 nativeValue: 0,
                 expiration: 0
-            }),
-            "WORMHOLE"
+            })
         );
     }
 
@@ -298,10 +294,10 @@ contract MultiMessageReceiverTest is Setup {
             expiration: type(uint256).max
         });
 
-        receiver.receiveMessage(message, "WORMHOLE");
+        receiver.receiveMessage(message);
 
         vm.expectRevert(Error.DUPLICATE_MESSAGE_DELIVERY_BY_ADAPTER.selector);
-        receiver.receiveMessage(message, "WORMHOLE");
+        receiver.receiveMessage(message);
     }
 
     /// @dev executed message should be rejected
@@ -322,13 +318,13 @@ contract MultiMessageReceiverTest is Setup {
         receiver.updateQuorum(1);
 
         vm.startPrank(wormholeAdapterAddr);
-        receiver.receiveMessage(message, "WORMHOLE");
+        receiver.receiveMessage(message);
 
         receiver.executeMessage(msgId);
 
         vm.startPrank(axelarAdapterAddr);
         vm.expectRevert(Error.MSG_ID_ALREADY_EXECUTED.selector);
-        receiver.receiveMessage(message, "AXELAR");
+        receiver.receiveMessage(message);
     }
 
     /// @dev executes message delivered by two adapters
@@ -346,10 +342,10 @@ contract MultiMessageReceiverTest is Setup {
         });
         bytes32 msgId = MessageLibrary.computeMsgId(message);
 
-        receiver.receiveMessage(message, "WORMHOLE");
+        receiver.receiveMessage(message);
 
         vm.startPrank(axelarAdapterAddr);
-        receiver.receiveMessage(message, "AXELAR");
+        receiver.receiveMessage(message);
 
         vm.expectEmit(true, true, true, true, address(receiver));
         emit MessageExecuted(msgId, address(42), 0, 42, bytes("42"));
@@ -374,7 +370,7 @@ contract MultiMessageReceiverTest is Setup {
         });
         bytes32 msgId = MessageLibrary.computeMsgId(message);
 
-        receiver.receiveMessage(message, "WORMHOLE");
+        receiver.receiveMessage(message);
 
         vm.expectRevert(Error.MSG_EXECUTION_PASSED_DEADLINE.selector);
         receiver.executeMessage(msgId);
@@ -395,10 +391,10 @@ contract MultiMessageReceiverTest is Setup {
         });
         bytes32 msgId = MessageLibrary.computeMsgId(message);
 
-        receiver.receiveMessage(message, "WORMHOLE");
+        receiver.receiveMessage(message);
 
         vm.startPrank(axelarAdapterAddr);
-        receiver.receiveMessage(message, "AXELAR");
+        receiver.receiveMessage(message);
 
         receiver.executeMessage(msgId);
 
@@ -421,7 +417,7 @@ contract MultiMessageReceiverTest is Setup {
         });
         bytes32 msgId = MessageLibrary.computeMsgId(message);
 
-        receiver.receiveMessage(message, "WORMHOLE");
+        receiver.receiveMessage(message);
 
         vm.expectRevert(Error.QUORUM_NOT_ACHIEVED.selector);
         receiver.executeMessage(msgId);
@@ -589,7 +585,7 @@ contract MultiMessageReceiverTest is Setup {
         });
         bytes32 msgId = MessageLibrary.computeMsgId(message);
 
-        receiver.receiveMessage(message, "WORMHOLE");
+        receiver.receiveMessage(message);
 
         (bool isExecuted, uint256 msgCurrentVotes, string[] memory successfulBridge) = receiver.getMessageInfo(msgId);
         assertFalse(isExecuted);

--- a/test/unit-tests/adapters/axelar/AxelarReceiverAdapter.t.sol
+++ b/test/unit-tests/adapters/axelar/AxelarReceiverAdapter.t.sol
@@ -41,7 +41,7 @@ contract AxelarReceiverAdapterTest is Setup {
 
     /// @dev gets the name
     function test_name() public {
-        assertEq(adapter.name(), "axelar");
+        assertEq(adapter.name(), "AXELAR");
     }
 
     /// @dev updates sender adapter

--- a/test/unit-tests/adapters/wormhole/WormholeReceiverAdapter.t.sol
+++ b/test/unit-tests/adapters/wormhole/WormholeReceiverAdapter.t.sol
@@ -49,7 +49,7 @@ contract WormholeReceiverAdapterTest is Setup {
 
     /// @dev gets the name
     function test_name() public {
-        assertEq(adapter.name(), "wormhole");
+        assertEq(adapter.name(), "WORMHOLE");
     }
 
     /// @dev updates sender adapter


### PR DESCRIPTION
Removes the need to pass the bridge name to the `MultiMessageReceiver.receiveMessage()` function. 