### PR TITLE
Fix missing events in three state update functions

### DIFF
--- a/src/MultiBridgeMessageReceiver.sol
+++ b/src/MultiBridgeMessageReceiver.sol
@@ -179,7 +179,9 @@ contract MultiBridgeMessageReceiver is IMultiBridgeMessageReceiver, ExecutorAwar
         if (_governanceTimelock == address(0)) {
             revert Error.ZERO_GOVERNANCE_TIMELOCK();
         }
+        address oldGovernanceTimelock = governanceTimelock;
         governanceTimelock = _governanceTimelock;
+        emit GovernanceTimelockUpdated(oldGovernanceTimelock, governanceTimelock);
     }
 
     /// @notice Update bridge receiver adapters.

--- a/src/MultiBridgeMessageReceiver.sol
+++ b/src/MultiBridgeMessageReceiver.sol
@@ -181,7 +181,7 @@ contract MultiBridgeMessageReceiver is IMultiBridgeMessageReceiver, ExecutorAwar
         }
         address oldGovernanceTimelock = governanceTimelock;
         governanceTimelock = _governanceTimelock;
-        emit GovernanceTimelockUpdated(oldGovernanceTimelock, governanceTimelock);
+        emit GovernanceTimelockUpdated(oldGovernanceTimelock, _governanceTimelock);
     }
 
     /// @notice Update bridge receiver adapters.

--- a/src/adapters/axelar/AxelarSenderAdapter.sol
+++ b/src/adapters/axelar/AxelarSenderAdapter.sol
@@ -12,8 +12,8 @@ import "./interfaces/IAxelarGasService.sol";
 import "./libraries/StringAddressConversion.sol";
 
 contract AxelarSenderAdapter is BaseSenderAdapter {
-    /// @notice event emitted when chain id mapping is updated
-    event ChainIDMappingUpdated(uint256[] origIds, string[] axlIds);
+    /// @notice event emitted when a chain id mapping is updated
+    event ChainIDMappingUpdated(uint256 indexed origId, string oldAxlId, string newAxlId);
 
     string public constant name = "AXELAR";
 
@@ -85,13 +85,15 @@ contract AxelarSenderAdapter is BaseSenderAdapter {
                 revert Error.ZERO_CHAIN_ID();
             }
 
+            string memory oldAxlId = chainIdMap[_origIds[i]];
             chainIdMap[_origIds[i]] = _axlIds[i];
+
+            emit ChainIDMappingUpdated(_origIds[i], oldAxlId, _axlIds[i]);
 
             unchecked {
                 ++i;
             }
         }
-        emit ChainIDMappingUpdated(_origIds, _axlIds);
     }
 
     /*/////////////////////////////////////////////////////////////////

--- a/src/adapters/axelar/AxelarSenderAdapter.sol
+++ b/src/adapters/axelar/AxelarSenderAdapter.sol
@@ -12,6 +12,7 @@ import "./interfaces/IAxelarGasService.sol";
 import "./libraries/StringAddressConversion.sol";
 
 contract AxelarSenderAdapter is BaseSenderAdapter {
+    /// @notice event emitted when chain id mapping is updated
     event ChainIDMappingUpdated(uint256[] origIds, string[] axlIds);
 
     string public constant name = "AXELAR";

--- a/src/adapters/axelar/AxelarSenderAdapter.sol
+++ b/src/adapters/axelar/AxelarSenderAdapter.sol
@@ -12,6 +12,8 @@ import "./interfaces/IAxelarGasService.sol";
 import "./libraries/StringAddressConversion.sol";
 
 contract AxelarSenderAdapter is BaseSenderAdapter {
+    event ChainIDMappingUpdated(uint256[] origIds, string[] axlIds);
+
     string public constant name = "AXELAR";
 
     IAxelarGateway public immutable gateway;
@@ -84,6 +86,7 @@ contract AxelarSenderAdapter is BaseSenderAdapter {
                 ++i;
             }
         }
+        emit ChainIDMappingUpdated(_origIds, _axlIds);
     }
 
     /*/////////////////////////////////////////////////////////////////

--- a/src/adapters/axelar/AxelarSenderAdapter.sol
+++ b/src/adapters/axelar/AxelarSenderAdapter.sol
@@ -81,6 +81,10 @@ contract AxelarSenderAdapter is BaseSenderAdapter {
         }
 
         for (uint256 i; i < arrLength;) {
+            if (_origIds[i] == 0) {
+                revert Error.ZERO_CHAIN_ID();
+            }
+
             chainIdMap[_origIds[i]] = _axlIds[i];
 
             unchecked {

--- a/src/adapters/wormhole/WormholeSenderAdapter.sol
+++ b/src/adapters/wormhole/WormholeSenderAdapter.sol
@@ -12,8 +12,8 @@ import "../../libraries/Types.sol";
 
 /// @notice sender adapter for wormhole bridge
 contract WormholeSenderAdapter is BaseSenderAdapter {
-    /// @notice event emitted when chain id mapping is updated
-    event ChainIDMappingUpdated(uint256[] origIds, uint16[] whIds);
+    /// @notice event emitted when a chain id mapping is updated
+    event ChainIDMappingUpdated(uint256 indexed origId, uint16 oldWhId, uint16 newWhId);
 
     string public constant name = "WORMHOLE";
     IWormholeRelayer public immutable relayer;
@@ -87,12 +87,14 @@ contract WormholeSenderAdapter is BaseSenderAdapter {
                 revert Error.ZERO_CHAIN_ID();
             }
 
+            uint16 oldWhId = chainIdMap[_origIds[i]];
             chainIdMap[_origIds[i]] = _whIds[i];
+
+            emit ChainIDMappingUpdated(_origIds[i], oldWhId, _whIds[i]);
 
             unchecked {
                 ++i;
             }
         }
-        emit ChainIDMappingUpdated(_origIds, _whIds);
     }
 }

--- a/src/adapters/wormhole/WormholeSenderAdapter.sol
+++ b/src/adapters/wormhole/WormholeSenderAdapter.sol
@@ -83,6 +83,10 @@ contract WormholeSenderAdapter is BaseSenderAdapter {
         }
 
         for (uint256 i; i < arrLength;) {
+            if (_origIds[i] == 0) {
+                revert Error.ZERO_CHAIN_ID();
+            }
+
             chainIdMap[_origIds[i]] = _whIds[i];
 
             unchecked {

--- a/src/adapters/wormhole/WormholeSenderAdapter.sol
+++ b/src/adapters/wormhole/WormholeSenderAdapter.sol
@@ -12,6 +12,9 @@ import "../../libraries/Types.sol";
 
 /// @notice sender adapter for wormhole bridge
 contract WormholeSenderAdapter is BaseSenderAdapter {
+    /// @notice event emitted when chain id mapping is updated
+    event ChainIDMappingUpdated(uint256[] origIds, uint16[] whIds);
+
     string public constant name = "WORMHOLE";
     IWormholeRelayer public immutable relayer;
 
@@ -86,5 +89,6 @@ contract WormholeSenderAdapter is BaseSenderAdapter {
                 ++i;
             }
         }
+        emit ChainIDMappingUpdated(_origIds, _whIds);
     }
 }

--- a/src/interfaces/IMultiBridgeMessageReceiver.sol
+++ b/src/interfaces/IMultiBridgeMessageReceiver.sol
@@ -48,6 +48,11 @@ interface IMultiBridgeMessageReceiver {
     /// @param newQuorum is the new quorum value
     event QuorumUpdated(uint64 oldQuorum, uint64 newQuorum);
 
+    /// @notice emitted when the governance timelock address is updated.
+    /// @param oldTimelock is the previous governance timelock contract address
+    /// @param newTimelock is the new governance timelock contract address
+    event GovernanceTimelockUpdated(address oldTimelock, address newTimelock);
+
     /// @notice Receive messages from allowed bridge receiver adapters.
     /// @dev Every receiver adapter should call this function with decoded MessageLibrary.Message
     /// @param _message is the message to be received
@@ -75,4 +80,8 @@ interface IMultiBridgeMessageReceiver {
         bool[] calldata _operations,
         uint64 _newQuorum
     ) external;
+
+    /// @notice updates the governance timelock address, which is the contract that ultimately executes valid messages.
+    /// @param  _newGovernanceTimelock is the new governance timelock contract address
+    function updateGovernanceTimelock(address _newGovernanceTimelock) external;
 }

--- a/test/unit-tests/MultiBridgeMessageReceiver.t.sol
+++ b/test/unit-tests/MultiBridgeMessageReceiver.t.sol
@@ -14,6 +14,7 @@ import {MultiBridgeMessageReceiver} from "src/MultiBridgeMessageReceiver.sol";
 contract MultiBridgeMessageReceiverTest is Setup {
     event BridgeReceiverAdapterUpdated(address indexed receiverAdapter, bool add);
     event QuorumUpdated(uint64 oldValue, uint64 newValue);
+    event GovernanceTimelockUpdated(address oldTimelock, address newTimelock);
     event BridgeMessageReceived(
         bytes32 indexed msgId, string indexed bridgeName, uint256 nonce, address receiverAdapter
     );
@@ -367,6 +368,9 @@ contract MultiBridgeMessageReceiverTest is Setup {
     /// @dev updates governance timelock
     function test_update_governance_timelock() public {
         vm.startPrank(timelockAddr);
+
+        vm.expectEmit(true, true, true, true, address(receiver));
+        emit GovernanceTimelockUpdated(receiver.governanceTimelock(), address(42));
 
         receiver.updateGovernanceTimelock(address(42));
         assertEq(receiver.governanceTimelock(), address(42));

--- a/test/unit-tests/adapters/axelar/AxelarSenderAdapter.t.sol
+++ b/test/unit-tests/adapters/axelar/AxelarSenderAdapter.t.sol
@@ -13,7 +13,7 @@ contract AxelarSenderAdapterTest is Setup {
     event MessageDispatched(
         bytes32 indexed messageId, address indexed from, uint256 indexed receiverChainId, address to, bytes data
     );
-    event ChainIDMappingUpdated(uint256[] origIds, string[] axlIds);
+    event ChainIDMappingUpdated(uint256 indexed origId, string oldAxlId, string newAxlId);
 
     address senderAddr;
     AxelarSenderAdapter adapter;
@@ -111,7 +111,7 @@ contract AxelarSenderAdapterTest is Setup {
         axlIds[0] = "42";
 
         vm.expectEmit(true, true, true, true, address(adapter));
-        emit ChainIDMappingUpdated(origIds, axlIds);
+        emit ChainIDMappingUpdated(origIds[0], adapter.chainIdMap(DST_CHAIN_ID), axlIds[0]);
 
         adapter.setChainIdMap(origIds, axlIds);
 

--- a/test/unit-tests/adapters/axelar/AxelarSenderAdapter.t.sol
+++ b/test/unit-tests/adapters/axelar/AxelarSenderAdapter.t.sol
@@ -133,4 +133,12 @@ contract AxelarSenderAdapterTest is Setup {
         vm.expectRevert(Error.ARRAY_LENGTH_MISMATCHED.selector);
         adapter.setChainIdMap(new uint256[](0), new string[](1));
     }
+
+    /// @dev cannot set chain ID map with invalid chain ID
+    function test_set_chain_id_map_zero_chain_id() public {
+        vm.startPrank(owner);
+
+        vm.expectRevert(Error.ZERO_CHAIN_ID.selector);
+        adapter.setChainIdMap(new uint256[](1), new string[](1));
+    }
 }

--- a/test/unit-tests/adapters/axelar/AxelarSenderAdapter.t.sol
+++ b/test/unit-tests/adapters/axelar/AxelarSenderAdapter.t.sol
@@ -13,6 +13,7 @@ contract AxelarSenderAdapterTest is Setup {
     event MessageDispatched(
         bytes32 indexed messageId, address indexed from, uint256 indexed receiverChainId, address to, bytes data
     );
+    event ChainIDMappingUpdated(uint256[] origIds, string[] axlIds);
 
     address senderAddr;
     AxelarSenderAdapter adapter;
@@ -108,6 +109,10 @@ contract AxelarSenderAdapterTest is Setup {
         origIds[0] = DST_CHAIN_ID;
         string[] memory axlIds = new string[](1);
         axlIds[0] = "42";
+
+        vm.expectEmit(true, true, true, true, address(adapter));
+        emit ChainIDMappingUpdated(origIds, axlIds);
+
         adapter.setChainIdMap(origIds, axlIds);
 
         assertEq(adapter.chainIdMap(DST_CHAIN_ID), "42");

--- a/test/unit-tests/adapters/wormhole/WormholeSenderAdapter.t.sol
+++ b/test/unit-tests/adapters/wormhole/WormholeSenderAdapter.t.sol
@@ -14,6 +14,7 @@ contract WormholeSenderAdapterTest is Setup {
     event MessageDispatched(
         bytes32 indexed messageId, address indexed from, uint256 indexed receiverChainId, address to, bytes data
     );
+    event ChainIDMappingUpdated(uint256[] origIds, uint16[] whIds);
 
     address senderAddr;
     WormholeSenderAdapter adapter;
@@ -105,6 +106,10 @@ contract WormholeSenderAdapterTest is Setup {
         origIds[0] = DST_CHAIN_ID;
         uint16[] memory whIds = new uint16[](1);
         whIds[0] = 42;
+
+        vm.expectEmit(true, true, true, true, address(adapter));
+        emit ChainIDMappingUpdated(origIds, whIds);
+
         adapter.setChainIdMap(origIds, whIds);
 
         assertEq(adapter.chainIdMap(DST_CHAIN_ID), 42);

--- a/test/unit-tests/adapters/wormhole/WormholeSenderAdapter.t.sol
+++ b/test/unit-tests/adapters/wormhole/WormholeSenderAdapter.t.sol
@@ -14,7 +14,7 @@ contract WormholeSenderAdapterTest is Setup {
     event MessageDispatched(
         bytes32 indexed messageId, address indexed from, uint256 indexed receiverChainId, address to, bytes data
     );
-    event ChainIDMappingUpdated(uint256[] origIds, uint16[] whIds);
+    event ChainIDMappingUpdated(uint256 indexed origId, uint16 oldWhId, uint16 newWhId);
 
     address senderAddr;
     WormholeSenderAdapter adapter;
@@ -108,7 +108,7 @@ contract WormholeSenderAdapterTest is Setup {
         whIds[0] = 42;
 
         vm.expectEmit(true, true, true, true, address(adapter));
-        emit ChainIDMappingUpdated(origIds, whIds);
+        emit ChainIDMappingUpdated(origIds[0], adapter.chainIdMap(DST_CHAIN_ID), whIds[0]);
 
         adapter.setChainIdMap(origIds, whIds);
 

--- a/test/unit-tests/adapters/wormhole/WormholeSenderAdapter.t.sol
+++ b/test/unit-tests/adapters/wormhole/WormholeSenderAdapter.t.sol
@@ -130,4 +130,12 @@ contract WormholeSenderAdapterTest is Setup {
         vm.expectRevert(Error.ARRAY_LENGTH_MISMATCHED.selector);
         adapter.setChainIdMap(new uint256[](0), new uint16[](1));
     }
+
+    /// @dev cannot set chain ID map with invalid chain ID
+    function test_set_chain_id_map_zero_chain_id() public {
+        vm.startPrank(owner);
+
+        vm.expectRevert(Error.ZERO_CHAIN_ID.selector);
+        adapter.setChainIdMap(new uint256[](1), new uint16[](1));
+    }
 }


### PR DESCRIPTION
This PR fixes #92  and adds additional validations relating to adapter-specific chain ID mappings.